### PR TITLE
Modify user interface to material3

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'dart:math';
 //import 'package:flutter/services.dart';
 
 import 'package:clipboard/clipboard.dart';
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_pty/flutter_pty.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -49,14 +50,23 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Tiny Computer',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-        //fontFamily: "FiraCode",
-      ),
-      home: const MyHomePage(title: 'Tiny Computer'),
+    return DynamicColorBuilder(
+        builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
+          return MaterialApp(
+            title: 'Tiny Computer',
+            theme: ThemeData(
+              colorScheme: lightDynamic,
+              useMaterial3: true,
+              //fontFamily: "FiraCode",
+            ),
+            darkTheme: ThemeData(
+              colorScheme: darkDynamic,
+              useMaterial3: true,
+              //fontFamily: "FiraCode",
+            ),
+            home: const MyHomePage(title: 'Tiny Computer'),
+          );
+        }
     );
   }
 }
@@ -1516,7 +1526,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text(isLoadingComplete?Util.getCurrentProp("name"):widget.title),
       ),
       body: isLoadingComplete?Column(mainAxisSize: MainAxisSize.min, children: [
@@ -1564,15 +1573,25 @@ class _MyHomePageState extends State<MyHomePage> {
         }))]):const LoadingPage(),
       bottomNavigationBar: ValueListenableBuilder(valueListenable: G.pageIndex, builder:(context, value, child) {
         return Visibility(visible: isLoadingComplete,
-          child: BottomNavigationBar(currentIndex: G.pageIndex.value, 
-            onTap: (index) {
+          // child: BottomNavigationBar(currentIndex: G.pageIndex.value,
+          //   onTap: (index) {
+          //     G.pageIndex.value = index;
+          //   },
+          //   items: const [
+          //     BottomNavigationBarItem(icon: Icon(Icons.monitor), label: "终端"),
+          //     BottomNavigationBarItem(icon: Icon(Icons.video_settings), label: "控制"),
+          //   ],
+          // )
+          child: NavigationBar(
+            selectedIndex: G.pageIndex.value,
+            destinations: const [
+              NavigationDestination(icon: Icon(Icons.monitor), label: "终端"),
+              NavigationDestination(icon: Icon(Icons.video_settings), label: "控制")
+            ],
+            onDestinationSelected: (index) {
               G.pageIndex.value = index;
             },
-            items: const [
-              BottomNavigationBarItem(icon: Icon(Icons.monitor), label: "终端"),
-              BottomNavigationBarItem(icon: Icon(Icons.video_settings), label: "控制"),
-            ],
-          )
+          ),
         );}),
       floatingActionButton: ValueListenableBuilder(valueListenable: G.pageIndex, builder:(context, value, child) {
         return Visibility(visible: isLoadingComplete && (value == 0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  dynamic_color:
+    dependency: "direct main"
+    description:
+      name: dynamic_color
+      sha256: a866f1f8947bfdaf674d7928e769eac7230388a2e7a2542824fad4bb5b87be3b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.9"
   equatable:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   clipboard: ^0.1.3
   ffmpeg_kit_flutter_full_gpl: ^6.0.3
   wakelock_plus: ^1.1.4
-
+  dynamic_color: ^1.6.9
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
根据Material Design3设计规范修改用户界面:  
1.使用[dynamic_color](https://pub.dev/packages/dynamic_color)插件适配Android 12动态取色.  
2.应用栏(AppBar)改为默认配色.  
3.导航栏(NavigationBar)改为Material3样式.  