### PR TITLE
修复:AVNC原生界面与Flutter界面样式不符

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     kapt "androidx.room:room-compiler:$roomVersion"
 
     
-    implementation "com.google.android.material:material:1.7.0"
+    implementation "com.google.android.material:material:1.11.0"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
     implementation "org.connectbot:sshlib:2.2.23"
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application
         android:label="小小电脑"
-        android:name="${applicationName}"
+        android:name=".MainApplication"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true"
         android:theme="@style/App.Theme">

--- a/android/app/src/main/kotlin/com/example/tiny_computer/MainApplication.kt
+++ b/android/app/src/main/kotlin/com/example/tiny_computer/MainApplication.kt
@@ -1,0 +1,12 @@
+package com.example.tiny_computer
+
+import com.google.android.material.color.DynamicColors
+import io.flutter.app.FlutterApplication
+
+class MainApplication : FlutterApplication() {
+
+    override fun onCreate() {
+        super.onCreate()
+        DynamicColors.applyToActivitiesIfAvailable(this@MainApplication)
+    }
+}

--- a/android/app/src/main/kotlin/com/gaurav/avnc/ui/about/AboutActivity.kt
+++ b/android/app/src/main/kotlin/com/gaurav/avnc/ui/about/AboutActivity.kt
@@ -9,7 +9,10 @@
 package com.gaurav.avnc.ui.about
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.example.tiny_computer.R
 
 /**
@@ -23,11 +26,18 @@ class AboutActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_about)
         setSupportActionBar(findViewById(R.id.toolbar))
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.about_main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
 
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()

--- a/android/app/src/main/kotlin/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
+++ b/android/app/src/main/kotlin/com/gaurav/avnc/ui/prefs/PrefsActivity.kt
@@ -12,9 +12,12 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.Keep
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
@@ -26,9 +29,15 @@ class PrefsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPreference
 
     override fun onCreate(savedInstanceState: Bundle?) {
         DeviceAuthPrompt.applyFingerprintDialogFix(supportFragmentManager)
-
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.settings_main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
 
         if (savedInstanceState == null) {
             supportFragmentManager

--- a/android/app/src/main/res/layout/activity_about.xml
+++ b/android/app/src/main/res/layout/activity_about.xml
@@ -6,6 +6,7 @@
   ~ See COPYING.txt for more details.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/about_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/android/app/src/main/res/layout/activity_settings.xml
+++ b/android/app/src/main/res/layout/activity_settings.xml
@@ -7,6 +7,7 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/settings_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -31,29 +31,29 @@
       Note: Some custom ROMs don't respect/support the splash theme introduced in API 31.
       On such devices, we still rely on the above mentioned workaround.
     -->
-    <style name="App.SplashTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+    <style name="App.SplashTheme" parent="Theme.Material3.DayNight.NoActionBar" />
 
-    <style name="App.SplashTheme.Light" parent="Theme.MaterialComponents.Light.NoActionBar" />
+    <style name="App.SplashTheme.Light" parent="Theme.Material3.Light.NoActionBar" />
 
-    <style name="App.SplashTheme.Dark" parent="Theme.MaterialComponents.NoActionBar" />
+    <style name="App.SplashTheme.Dark" parent="Theme.Material3.Dark.NoActionBar" />
 
     <!--
       This base theme is used for configuration-specific styling (e.g. night mode, API 23)
     -->
-    <style name="App.BaseTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+    <style name="App.BaseTheme" parent="Theme.Material3.DayNight.NoActionBar" />
 
     <!--
       This is the main theme.
     -->
     <style name="App.Theme" parent="App.BaseTheme">
-        <item name="appBarLayoutStyle">@style/Widget.MaterialComponents.AppBarLayout.Surface</item>
+        <item name="appBarLayoutStyle">@style/Widget.Material3.AppBarLayout</item>
     </style>
 
-    <style name="AlertDialog.Dimmed" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+    <style name="AlertDialog.Dimmed" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="android:backgroundDimAmount">.6</item>
     </style>
 
-    <style name="UrlBar" parent="Widget.MaterialComponents.Toolbar">
+    <style name="UrlBar" parent="Widget.Material3.Toolbar">
         <item name="android:background">@drawable/bg_urlbar</item>
         <item name="android:layout_marginStart">@dimen/margin_normal</item>
         <item name="android:layout_marginEnd">@dimen/margin_normal</item>
@@ -138,7 +138,7 @@
         <item name="android:minWidth">50dp</item>
         <item name="android:gravity">center</item>
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
-        <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Body2</item>
+        <item name="android:textAppearance">@style/TextAppearance.Material3.BodyMedium</item>
     </style>
 
     <style name="VirtualKey.Compact">

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,4 +23,5 @@ plugins {
     id "org.jetbrains.kotlin.android" version "1.9.22" apply false
 }
 
+rootProject.name = "TinyComputer"
 include ":app"


### PR DESCRIPTION
1.更新Android端material库为1.11.0
2.在Android端启用动态颜色
3.更改主题样式为Material3
4.为两个原生页面启用边倒边沉浸
5.修改Android端项目名称为TinyComputer(顺手改了, 默认为android)