### PR TITLE
适配 Flutter 3.38+：使用官方 AssetManifest API 替换已移除的 json

### DIFF
--- a/lib/workflow.dart
+++ b/lib/workflow.dart
@@ -612,7 +612,14 @@ chmod 1777 tmp
     Util.createDirFromString("${G.dataPath}/containers/0/.l2s");
     //这个是容器rootfs，被split命令分成了xa*，放在assets里
     //首次启动，就用这个，别让用户另选了
-    for (String name in jsonDecode(await rootBundle.loadString('AssetManifest.json')).keys.where((String e) => e.startsWith("assets/xa")).map((String e) => e.split("/").last).toList()) {
+	//使用 AssetManifest API 获取 assets/xa* 文件列表
+    final AssetManifest manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
+    final List<String> xaFiles = manifest
+        .listAssets()
+        .where((String key) => key.startsWith('assets/xa'))
+        .map((String key) => key.split('/').last)
+        .toList();
+    for (String name in xaFiles) {
       await Util.copyAsset("assets/$name", "${G.dataPath}/$name");
     }
     //-J


### PR DESCRIPTION
从 Flutter 3.38.0 开始，构建产物中不再生成 AssetManifest.json 文件了（官方已切换到更高效的 AssetManifest.bin 格式）。
详情见：

发布笔记：https://docs.flutter.dev/release/release-notes/release-notes-3.38.0
Breaking change：https://docs.flutter.dev/release/breaking-changes/asset-manifest-dot-json

原来代码通过手动读取 AssetManifest.json 来获取 assets/xa* 分卷文件，在新版 Flutter 下可能会运行出错。
这次修改把这部分换成了 Flutter 官方推荐的方式：
使用 AssetManifest.loadFromAssetBundle(rootBundle).listAssets() 来获取资产列表。