### PR TITLE
feat: file-based import/export for Quicks config

### DIFF
--- a/app/src/main/java/com/fct/tc4/ui/page/QuicksFragment.kt
+++ b/app/src/main/java/com/fct/tc4/ui/page/QuicksFragment.kt
@@ -18,11 +18,13 @@
 package com.fct.tc4.ui.page
 
 import android.content.Context
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -85,6 +87,16 @@ class QuicksFragment : Fragment() {
             QuicksViewModel.Tab.COMMANDS -> "commands"
             QuicksViewModel.Tab.OPTIONS -> "options"
         }
+
+    // ========== 文件导入/导出（Storage Access Framework） ==========
+
+    private val exportToFileLauncher = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("application/x-yaml")
+    ) { uri -> uri?.let { writeExport(it) } }
+
+    private val importFromFileLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri -> uri?.let { readImport(it) } }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -203,6 +215,16 @@ class QuicksFragment : Fragment() {
             } else {
                 Snackbar.make(binding.root, getString(R.string.tc4_quick_import_failed, result.errors.first()), Snackbar.LENGTH_LONG).show()
             }
+        }
+
+        // ========== export_to_file / import_from_file ==========
+
+        binding.exportToFile.setOnClickListener {
+            exportToFileLauncher.launch("tiny_container_quicks.yaml")
+        }
+
+        binding.importFromFile.setOnClickListener {
+            importFromFileLauncher.launch(arrayOf("*/*"))
         }
 
         // ========== add_folder ==========
@@ -348,6 +370,8 @@ class QuicksFragment : Fragment() {
 
                 binding.buttonGroup.isEnabled = !selecting
                 binding.importFromClipboard.isEnabled = !selecting
+                binding.exportToFile.isEnabled = !selecting
+                binding.importFromFile.isEnabled = !selecting
                 binding.addFolder.isEnabled = !selecting
                 binding.add.isEnabled = !selecting
                 setChipGroupEnabled(!selecting)
@@ -455,6 +479,54 @@ class QuicksFragment : Fragment() {
             } else {
                 chip.visibility = View.VISIBLE
             }
+        }
+    }
+
+    /** 将整份 Quicks 配置写入用户选择的文件 */
+    private fun writeExport(uri: Uri) {
+        try {
+            val yamlText = viewModel.exportAllToYaml()
+            requireContext().contentResolver.openOutputStream(uri)?.use { out ->
+                out.write(yamlText.toByteArray())
+            } ?: throw java.io.IOException("openOutputStream returned null")
+            Snackbar.make(binding.root, R.string.tc4_quick_export_file_success, Snackbar.LENGTH_SHORT).show()
+        } catch (e: Exception) {
+            Snackbar.make(
+                binding.root,
+                getString(R.string.tc4_quick_export_file_failed, e.message),
+                Snackbar.LENGTH_LONG
+            ).show()
+        }
+    }
+
+    /** 读取用户选择的文件并导入整份 Quicks 配置 */
+    private fun readImport(uri: Uri) {
+        val text = try {
+            requireContext().contentResolver.openInputStream(uri)?.use { input ->
+                input.readBytes().decodeToString()
+            } ?: throw java.io.IOException("openInputStream returned null")
+        } catch (e: Exception) {
+            Snackbar.make(
+                binding.root,
+                getString(R.string.tc4_quick_import_failed, e.message),
+                Snackbar.LENGTH_LONG
+            ).show()
+            return
+        }
+
+        val result = viewModel.importAllFromYaml(text, requireContext())
+        if (result.errors.isEmpty()) {
+            Snackbar.make(binding.root, getString(R.string.tc4_quick_import_success, result.successCount), Snackbar.LENGTH_SHORT).show()
+        } else if (result.successCount > 0) {
+            Snackbar.make(
+                binding.root,
+                getString(R.string.tc4_quick_import_partial, result.successCount, result.errors.size),
+                Snackbar.LENGTH_LONG
+            ).setAction(R.string.tc4_btn_details) {
+                Snackbar.make(binding.root, result.errors.joinToString("\n"), Snackbar.LENGTH_LONG).show()
+            }.show()
+        } else {
+            Snackbar.make(binding.root, getString(R.string.tc4_quick_import_failed, result.errors.first()), Snackbar.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/fct/tc4/ui/page/QuicksViewModel.kt
+++ b/app/src/main/java/com/fct/tc4/ui/page/QuicksViewModel.kt
@@ -227,6 +227,12 @@ class QuicksViewModel(application: Application) : AndroidViewModel(application) 
         clipboard.setPrimaryClip(ClipData.newPlainText("yaml", yamlText))
     }
 
+    /** 导出整份 Quicks 配置（quick_commands + options）为 YAML 文本，用于写入文件 */
+    fun exportAllToYaml(): String {
+        val config = configRef ?: return ""
+        return exportConfigToYaml(config)
+    }
+
     // ===================== 叶子节点操作 =====================
 
     @Suppress("UNCHECKED_CAST")
@@ -286,6 +292,56 @@ class QuicksViewModel(application: Application) : AndroidViewModel(application) 
         }
 
         return ImportResult(validNodes.size, errors)
+    }
+
+    /** 从文件读取的 YAML 文本导入整份配置：校验后合并 quick_commands 与 options 并保存 */
+    fun importAllFromYaml(text: String, context: Context): ImportResult {
+        val parsed: Map<*, *> = try {
+            when (val raw: Any? = Yaml().load(text)) {
+                is Map<*, *> -> raw
+                null -> return ImportResult(0, listOf(context.getString(R.string.tc4_validate_clipboard_content_empty)))
+                else -> return ImportResult(0, listOf(context.getString(R.string.tc4_validate_yaml_not_object)))
+            }
+        } catch (e: Exception) {
+            return ImportResult(0, listOf(context.getString(R.string.tc4_validate_yaml_format_error, e.message)))
+        }
+
+        val errors = mutableListOf<String>()
+        var successCount = 0
+        successCount += importSubtree(parsed["quick_commands"], "quick_commands", setOf("command", "commands"), context, errors)
+        successCount += importSubtree(parsed["options"], "options", setOf("option", "options"), context, errors)
+
+        if (successCount > 0) save()
+        return ImportResult(successCount, errors)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun importSubtree(
+        raw: Any?, rootKey: String, validTypes: Set<String>,
+        context: Context, errors: MutableList<String>
+    ): Int {
+        if (raw == null) return 0
+        val nodes = (raw as? List<*>)?.filterNotNull() ?: run {
+            errors.add(context.getString(R.string.tc4_validate_yaml_not_object))
+            return 0
+        }
+
+        val validNodes = mutableListOf<Map<String, Any>>()
+        nodes.forEachIndexed { i, obj ->
+            val err = validateNode(obj, validTypes, context)
+            if (err != null) {
+                errors.add(getApplication<Application>().getString(R.string.tc4_validate_yaml_line_error, i + 1, err))
+            } else {
+                validNodes.add(obj as Map<String, Any>)
+            }
+        }
+
+        if (validNodes.isNotEmpty()) {
+            val list = configRef?.get(rootKey) as? MutableList<Any>
+                ?: mutableListOf<Any>().also { configRef?.put(rootKey, it) }
+            list.addAll(validNodes.map { it.toMutableMap() })
+        }
+        return validNodes.size
     }
 
     private fun validateNode(node: Any?, validTypes: Set<String>, context: Context): String? {
@@ -410,6 +466,16 @@ class QuicksViewModel(application: Application) : AndroidViewModel(application) 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return QuicksViewModel(application) as T
+        }
+    }
+
+    companion object {
+        /** 将整份配置的 quick_commands 与 options 子树序列化为 YAML（不依赖 Android Context，便于单测） */
+        fun exportConfigToYaml(config: Map<String, Any>): String {
+            val export = LinkedHashMap<String, Any>()
+            (config["quick_commands"] as? List<*>)?.let { export["quick_commands"] = it }
+            (config["options"] as? List<*>)?.let { export["options"] = it }
+            return Yaml().dump(export)
         }
     }
 }

--- a/app/src/main/res/layout-w600dp/tc4_fragment_quicks.xml
+++ b/app/src/main/res/layout-w600dp/tc4_fragment_quicks.xml
@@ -57,6 +57,20 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
                     <Button
+                        android:id="@+id/export_to_file"
+                        style="?attr/materialIconButtonStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:tooltipText="@string/tc4_quicks_cd_export_file"
+                        app:icon="@drawable/upload_24dp_1f1f1f_fill0_wght400_grad0_opsz24" />
+                    <Button
+                        android:id="@+id/import_from_file"
+                        style="?attr/materialIconButtonStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:tooltipText="@string/tc4_quicks_cd_import_file"
+                        app:icon="@drawable/download_24dp_1f1f1f_fill0_wght400_grad0_opsz24" />
+                    <Button
                         android:id="@+id/import_from_clipboard"
                         style="?attr/materialIconButtonStyle"
                         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/tc4_fragment_quicks.xml
+++ b/app/src/main/res/layout/tc4_fragment_quicks.xml
@@ -64,6 +64,20 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
                 <Button
+                    android:id="@+id/export_to_file"
+                    style="?attr/materialIconButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:tooltipText="@string/tc4_quicks_cd_export_file"
+                    app:icon="@drawable/upload_24dp_1f1f1f_fill0_wght400_grad0_opsz24" />
+                <Button
+                    android:id="@+id/import_from_file"
+                    style="?attr/materialIconButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:tooltipText="@string/tc4_quicks_cd_import_file"
+                    app:icon="@drawable/download_24dp_1f1f1f_fill0_wght400_grad0_opsz24" />
+                <Button
                     android:id="@+id/import_from_clipboard"
                     style="?attr/materialIconButtonStyle"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -141,6 +141,8 @@
     <string name="tc4_quick_import_partial">成功导入 %1$d 个，失败 %2$d 个</string>
     <string name="tc4_quick_import_failed">导入失败：%1$s</string>
     <string name="tc4_quick_copied">已复制 %1$d 个节点到剪贴板</string>
+    <string name="tc4_quick_export_file_success">已导出到文件</string>
+    <string name="tc4_quick_export_file_failed">导出失败：%1$s</string>
 
     <!-- ==================== Validation ==================== -->
     <string name="tc4_validate_name_empty">名称不能为空</string>
@@ -237,6 +239,8 @@
 
     <!-- ==================== Quicks Toolbar Content Descriptions ==================== -->
     <string name="tc4_quicks_cd_paste">粘贴</string>
+    <string name="tc4_quicks_cd_export_file">导出到文件</string>
+    <string name="tc4_quicks_cd_import_file">从文件导入</string>
     <string name="tc4_quicks_cd_add_folder">添加文件夹</string>
     <string name="tc4_quicks_cd_add">添加</string>
     <string name="tc4_quicks_cd_delete">删除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,8 @@
     <string name="tc4_quick_import_partial">Imported %1$d, failed %2$d</string>
     <string name="tc4_quick_import_failed">Import failed: %1$s</string>
     <string name="tc4_quick_copied">Copied %1$d node(s) to clipboard</string>
+    <string name="tc4_quick_export_file_success">Exported to file</string>
+    <string name="tc4_quick_export_file_failed">Export failed: %1$s</string>
 
     <!-- ==================== Validation ==================== -->
     <string name="tc4_validate_name_empty">Name cannot be empty</string>
@@ -237,6 +239,8 @@
 
     <!-- ==================== Quicks Toolbar Content Descriptions ==================== -->
     <string name="tc4_quicks_cd_paste">Paste</string>
+    <string name="tc4_quicks_cd_export_file">Export to File</string>
+    <string name="tc4_quicks_cd_import_file">Import from File</string>
     <string name="tc4_quicks_cd_add_folder">Add Folder</string>
     <string name="tc4_quicks_cd_add">Add</string>
     <string name="tc4_quicks_cd_delete">Delete</string>

--- a/app/src/test/java/com/fct/tc4/QuicksImportExportTest.kt
+++ b/app/src/test/java/com/fct/tc4/QuicksImportExportTest.kt
@@ -1,0 +1,75 @@
+// QuicksImportExportTest.kt -- This file is part of tiny_container.
+//
+// Copyright (C) 2026 Caten Hu
+//
+// Tiny Container is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License,
+// or any later version.
+//
+// Tiny Container is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/.
+
+package com.fct.tc4
+
+import com.fct.tc4.ui.page.QuicksViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.yaml.snakeyaml.Yaml
+
+/**
+ * Unit tests for the file-based Quicks export serialization. These cover the
+ * Context-free serialization helper used by [QuicksViewModel.exportAllToYaml];
+ * the import path relies on Android resources and is exercised on-device.
+ */
+class QuicksImportExportTest {
+
+    private fun sampleConfig(): Map<String, Any> = mapOf(
+        "quick_commands" to listOf(
+            mapOf("type" to "command", "name" to "ls", "command" to "ls -la"),
+            mapOf(
+                "type" to "commands", "name" to "folder",
+                "commands" to listOf(
+                    mapOf("type" to "command", "name" to "echo", "command" to "echo hi")
+                )
+            )
+        ),
+        "options" to listOf(
+            mapOf("type" to "option", "name" to "verbose", "enabled" to true)
+        ),
+        "unrelated" to "should not be exported"
+    )
+
+    @Test
+    fun export_includes_only_quicks_subtrees() {
+        val yaml = QuicksViewModel.exportConfigToYaml(sampleConfig())
+        assertTrue(yaml.contains("quick_commands"))
+        assertTrue(yaml.contains("options"))
+        assertTrue(!yaml.contains("unrelated"))
+    }
+
+    @Test
+    fun export_round_trips_through_yaml() {
+        val original = sampleConfig()
+        val yaml = QuicksViewModel.exportConfigToYaml(original)
+
+        @Suppress("UNCHECKED_CAST")
+        val parsed = Yaml().load<Any?>(yaml) as Map<String, Any>
+
+        assertEquals(original["quick_commands"], parsed["quick_commands"])
+        assertEquals(original["options"], parsed["options"])
+    }
+
+    @Test
+    fun export_omits_absent_subtree() {
+        val yaml = QuicksViewModel.exportConfigToYaml(mapOf("quick_commands" to emptyList<Any>()))
+        assertTrue(yaml.contains("quick_commands"))
+        assertTrue(!yaml.contains("options"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds file-based export and import for the whole Quicks configuration so users can save their shortcut commands and options to a file and restore them after uninstalling and reinstalling the app.

## Why this matters

Issue #537 asks to import/export the Quicks (快捷指令) config so shortcuts do not have to be rebuilt by hand after a reinstall. The app already exports/imports selected nodes through the clipboard (`QuicksViewModel.exportSelected` / `importFromClipboard`), but the clipboard only holds the current selection and does not survive a reinstall. This adds durable whole-config export to a file and import back from a file.

## What changed

- `QuicksViewModel`: `exportAllToYaml()` serializes the `quick_commands` and `options` subtrees to YAML via the existing SnakeYAML path, and `importAllFromYaml()` parses a file, validates each node through the existing `validateNode` path, merges the valid nodes, and calls `save()`. The pure serialization step lives in a `exportConfigToYaml` companion helper.
- `QuicksFragment`: two Storage Access Framework launchers (`CreateDocument` for export, `OpenDocument` for import) read and write through `contentResolver`, with the same Snackbar success/partial/error reporting used by the clipboard import.
- Two toolbar icon buttons added to both `tc4_fragment_quicks.xml` layout variants (default and `layout-w600dp`) and new strings in the default and `zh-rCN` resources.

## Testing

Added `QuicksImportExportTest` covering the export serialization (subtree selection, YAML round-trip, omission of absent subtrees). Imports and SAF flows depend on Android resources and were checked by reading through the clipboard import path they reuse. Note: a full Gradle build needs the Android SDK, which was not available in this environment.

Fixes #537
